### PR TITLE
[Console Server] Chain filter error

### DIFF
--- a/pkg/consolegraphql/cache/cache.go
+++ b/pkg/consolegraphql/cache/cache.go
@@ -187,7 +187,7 @@ func (r *MemdbCache) Get(idxName string, keyPrefix string, filter ObjectFilter) 
 					} else {
 						ok, cont, err := filter(obj)
 						if err != nil {
-							return objs, fmt.Errorf("filter failed for type: %T", obj)
+							return objs, fmt.Errorf("filter failed for type: %T %+v", obj, err)
 						} else if ok {
 							objs = append(objs, obj)
 						}


### PR DESCRIPTION
if the authorization fails during the access controller's RBAC checks, the filter currently loses the orginal cause, making debug harder. 

For instance, with this change you'll see:

`2020-03-27T15:06:22.177Z Query error - op: all_namespaces query: query all_namespaces {
 vars: map[] error: filter failed for type: *v1.Namespace users "kwall@apache.org" is forbidden: User "system:serviceaccount:enmasse-infra:console-server" cannot impersonate resource "users" in API group "" at the cluster scope`
